### PR TITLE
Credentials support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+*.iml
+.idea
+dependency-reduced-pom.xml

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -1,12 +1,17 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
 import antlr.ANTLRException;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -17,6 +22,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
+
 /**
  * Created by nishio
  */
@@ -24,8 +31,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
     private final String projectPath;
     private final String cron;
-    private final String username;
-    private final String password;
+    private final String credentialsId;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
@@ -41,8 +47,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public BitbucketBuildTrigger(
             String projectPath,
             String cron,
-            String username,
-            String password,
+            String credentialsId,
             String repositoryOwner,
             String repositoryName,
             String ciSkipPhrases,
@@ -52,8 +57,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
-        this.username = username;
-        this.password = password;
+        this.credentialsId = credentialsId;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
@@ -69,12 +73,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return this.cron;
     }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
+    public String getCredentialsId() {
+        return credentialsId;
     }
 
     public String getRepositoryOwner() {
@@ -179,6 +179,13 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             save();
             return super.configure(req, json);
+        }
+
+        public ListBoxModel doFillCredentialsIdItems() {
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withMatching(instanceOf(UsernamePasswordCredentials.class),
+                            CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class));
         }
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -32,6 +32,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String projectPath;
     private final String cron;
     private final String credentialsId;
+    private final String username;
+    private final String password;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
@@ -48,6 +50,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String projectPath,
             String cron,
             String credentialsId,
+            String username,
+            String password,
             String repositoryOwner,
             String repositoryName,
             String ciSkipPhrases,
@@ -58,6 +62,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.projectPath = projectPath;
         this.cron = cron;
         this.credentialsId = credentialsId;
+        this.username = username;
+        this.password = password;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
@@ -75,6 +81,14 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public String getRepositoryOwner() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -45,10 +45,17 @@ public class BitbucketRepository {
 
     public void init() {
         trigger = this.builder.getTrigger();
+        String username = trigger.getUsername();
+        String password = trigger.getPassword();
         StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
+        if (credentials != null) {
+            username = credentials.getUsername();
+            password = credentials.getPassword().getPlainText();
+        }
+
         client = new ApiClient(
-                credentials.getUsername(),
-                credentials.getPassword().getPlainText(),
+                username,
+                password,
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName());
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -10,6 +10,12 @@ import java.util.regex.Pattern;
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
 
 /**
  * Created by nishio
@@ -39,9 +45,10 @@ public class BitbucketRepository {
 
     public void init() {
         trigger = this.builder.getTrigger();
+        StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
         client = new ApiClient(
-                trigger.getUsername(),
-                trigger.getPassword(),
+                credentials.getUsername(),
+                credentials.getPassword().getPlainText(),
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName());
     }
@@ -191,5 +198,13 @@ public class BitbucketRepository {
             }
         }
         return false;
+    }
+
+    private StandardUsernamePasswordCredentials getCredentials(String credentialsId) {
+        return CredentialsMatchers
+                .firstOrNull(
+                        CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class),
+                        CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId),
+                                instanceOf(UsernamePasswordCredentials.class)));
     }
 }

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -5,6 +5,12 @@
   <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
   </f:entry>
+  <f:entry title="Bitbucket BasicAuth Username" field="username">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Bitbucket BasicAuth Password" field="password">
+    <f:password />
+  </f:entry>
   <f:entry title="RepositoryOwner" field="repositoryOwner">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -1,12 +1,9 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
-  <f:entry title="Bitbucket BasicAuth Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Bitbucket BasicAuth Password" field="password">
-    <f:password />
+  <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
   </f:entry>
   <f:entry title="RepositoryOwner" field="repositoryOwner">
     <f:textbox />

--- a/src/test/java/BitbucketBuildFilterTest.java
+++ b/src/test/java/BitbucketBuildFilterTest.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildFilter;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketCause;
@@ -10,9 +5,7 @@ import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequ
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -25,8 +18,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
 /**
- *
- * @author maxvodo
+ * Tests
  */
 public class BitbucketBuildFilterTest {
   
@@ -287,25 +279,5 @@ public class BitbucketBuildFilterTest {
     String myBuildKey = "902f259e962ff16100843123480a0970";
     for(Pullrequest.Comment comment : comments)
       assertFalse(repo.hasMyBuildTagInTTPComment(comment.getContent(), myBuildKey));
-  }
-  
-  //@Test
-  @WithoutJenkins
-  public void ttpCommentTest() {    
-    ApiClient client = EasyMock.createNiceMock(ApiClient.class);
-    Collection<List<Pullrequest>> prs = new LinkedList<List<Pullrequest>>();
-    
-    prs.add(Arrays.asList(new Pullrequest[] {
-      new Pullrequest()
-    }));
-    
-    for(List<Pullrequest> pr : prs) EasyMock.expect(client.getPullRequests()).andReturn(pr).times(1);
-    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class);
-    EasyMock.replay(client, builder);
-    
-    BitbucketRepository repo = new BitbucketRepository("", builder);
-    repo.init(client);
-    
-    Collection<Pullrequest> targetPRs = repo.getTargetPullRequests();
   }
 }

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -1,0 +1,153 @@
+
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequestsBuilder;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import org.easymock.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import jenkins.model.Jenkins;
+import org.apache.commons.httpclient.Credentials;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.junit.Assert;
+
+
+interface ICredentialsInterceptor {
+  void assertCredentials(Credentials actual);
+}
+
+/**
+ * Utility class for interceptor functionality
+ * @param <T> 
+ */
+class HttpClientInterceptor<T extends ICredentialsInterceptor> extends HttpClient {  
+  
+  class CredentialsInterceptor<T extends ICredentialsInterceptor> extends HttpState {
+    private final T interceptor;
+    public CredentialsInterceptor(T interceptor) { this.interceptor = interceptor; }
+    
+    @Override
+    public synchronized void setCredentials(AuthScope authscope, Credentials credentials) {      
+      super.setCredentials(authscope, credentials);
+      this.interceptor.assertCredentials(credentials);
+      throw new AssertionError();
+    }    
+  }  
+  
+  private final T interceptor;
+  public HttpClientInterceptor(T interceptor) { this.interceptor = interceptor; }
+  
+  @Override
+  public synchronized HttpState getState() { return new CredentialsInterceptor(this.interceptor); }  
+}
+
+/**
+ * Utility class for credentials assertion
+ * Used with 
+ * @author maxvodo
+ */
+class AssertCredentials implements ICredentialsInterceptor {
+  private final Credentials expected;
+  public AssertCredentials(Credentials expected) { this.expected = expected; }
+
+  public void assertCredentials(Credentials actual) {
+    if (actual == null) assertTrue(this.expected == null); 
+                   else assertTrue(this.expected != null);        
+
+    if (actual instanceof UsernamePasswordCredentials) {
+      UsernamePasswordCredentials actual_ = (UsernamePasswordCredentials)actual,
+                                  expected_ = (UsernamePasswordCredentials)this.expected;
+      assertNotNull(expected_);
+      Assert.assertArrayEquals(new Object[] {
+        actual_.getUserName(), actual_.getPassword()
+      }, new Object[] {
+        expected_.getUserName(), expected_.getPassword()
+      });
+    }
+  }      
+}
+
+/**
+ * Tests
+ */
+public class BitbucketBuildRepositoryTest {
+
+  @Rule
+  public JenkinsRule jRule = new JenkinsRule();  
+  
+  @Test  
+  public void repositorySimpleUserPasswordTest() throws Exception {
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "", "", "",
+      true, 
+      true
+    );
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    EasyMock.replay(builder);
+    
+    ApiClient.HttpClientFactory httpFactory = EasyMock.createMock(ApiClient.HttpClientFactory.class);
+    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
+      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("foo", "bar")))
+    ).anyTimes();
+    EasyMock.replay(httpFactory);            
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init(httpFactory.getClass());
+    
+    try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }
+  }
+  
+  @Test  
+  public void repositoryCtorWithTriggerTest() throws Exception {
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "", "", "",
+      true, 
+      true
+    );          
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    EasyMock.replay(builder);
+    
+    CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+    assertNotNull(store);
+    store.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+      CredentialsScope.GLOBAL, "JenkinsCID", "description", "username", "password"
+    ));
+    
+    ApiClient.HttpClientFactory httpFactory = EasyMock.createMock(ApiClient.HttpClientFactory.class);
+    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
+      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("username", "password")))
+    ).anyTimes();
+    EasyMock.replay(httpFactory);  
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init(httpFactory.getClass());        
+    
+    try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }                
+  }
+}


### PR DESCRIPTION
By default we using username/password from original text fields (config.jelly).
If credentials ID provided in plugin settings - using them for BitBucket API auth.
